### PR TITLE
Fix installation error

### DIFF
--- a/ha_skill/Dockerfile
+++ b/ha_skill/Dockerfile
@@ -2,9 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 # Install requirements for add-on
-RUN apk add --no-cache python3 py3-pip
-RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir requests boto3
+RUN apk add --no-cache python3 py3-pip py3-requests py3-boto3
 
 # Copy data for add-on
 COPY run.py /

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: Adamirr's Home Assistant Add-ons
-url: "https://github.com/adamirr/ha_addons"
-maintainer: adamirr
+name: Alexa Integration Test
+url: "https://github.com/applebee1558/ha_addons/tree/patch-1"
+maintainer: adamirr applebee

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: Alexa Integration Test
-url: "https://github.com/applebee1558/ha_addons/tree/patch-1"
-maintainer: adamirr applebee
+name: Adamirr's Home Assistant Add-ons
+url: "https://github.com/adamirr/ha_addons"
+maintainer: adamirr


### PR DESCRIPTION
Fixing the build error by installing packages with apk
Step 4/14 : RUN pip3 install --upgrade pip


 ---> Running in b2bbda780938

error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide python installation should be maintained using the system
    package manager (apk) only.
    
    If the package in question is not packaged already (and hence installable via
    "apk add py3-somepackage"), please consider installing it inside a virtual
    environment, e.g.:
    
    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by re-sourcing
    the activate file.
    
    To automatically manage virtual environments, consider using pipx (from the
    pipx package).

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.

Removing intermediate container b2bbda780938

23-12-11 23:48:56 INFO (MainThread) [supervisor.docker.addon] Starting build for a11dcb03/amd64-addon-ha_skill:1.0.4
23-12-11 23:49:00 ERROR (MainThread) [supervisor.docker.addon] Can't build a11dcb03/amd64-addon-ha_skill:1.0.4: The command '/bin/ash -o pipefail -c pip3 install --upgrade pip' returned a non-zero code: 1